### PR TITLE
Made FBPParticleEmitter run at effectively non-reflective speed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 
 
 group= "com.TominoCZ.FBP" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-version = "1.10.2"
+version = "1.10.2-2.1"
 archivesBaseName = "FancyBlockParticles"
 
 sourceCompatibility = targetCompatibility = "1.8" // Need this here so eclipse task generates correctly.

--- a/src/main/java/com/TominoCZ/FBP/math/FBPMathHelper.java
+++ b/src/main/java/com/TominoCZ/FBP/math/FBPMathHelper.java
@@ -3,6 +3,7 @@ package com.TominoCZ.FBP.math;
 import java.util.ArrayList;
 
 import net.minecraft.util.math.MathHelper;
+import scala.actors.threadpool.Arrays;
 
 public class FBPMathHelper {
 	static ArrayList<double[]> newVec = new ArrayList();
@@ -21,16 +22,26 @@ public class FBPMathHelper {
 	static float radsY;
 	static float radsZ;
 
-	public static ArrayList<double[]> rotateCubeXYZ(double AngleX, double AngleY, double AngleZ, double size) {
-		double center = (size / 2);
+	public static ArrayList<double[]> rotateCubeXYZ(double AngleX, double AngleY, double AngleZ, double halfSize) {
+		// cube = new double[] { center, -center, center, center, center,
+		// center, -center, center, center, -center,-center, center, -center,
+		// -center, -center, -center, center, -center, center, center, -center,
+		// center,-center, -center, -center, -center, center, -center, center,
+		// center, -center, center, -center, -center,-center, -center, center,
+		// -center, -center, center, center, -center, center, center, center,
+		// center,-center, center, -center, center, -center, -center, center,
+		// center, center, center, center, center,center, -center, -center,
+		// -center, center, -center, -center, -center, center, -center, -center,
+		// center,-center, center };
 
-		cube = new double[] { center, -center, center, center, center, center, -center, center, center, -center,
-				-center, center, -center, -center, -center, -center, center, -center, center, center, -center, center,
-				-center, -center, -center, -center, center, -center, center, center, -center, center, -center, -center,
-				-center, -center, center, -center, -center, center, center, -center, center, center, center, center,
-				-center, center, -center, center, -center, -center, center, center, center, center, center, center,
-				center, -center, -center, -center, center, -center, -center, -center, center, -center, -center, center,
-				-center, center };
+		cube = new double[] { -halfSize, -halfSize, halfSize, -halfSize, halfSize, halfSize, halfSize, halfSize,
+				halfSize, halfSize, -halfSize, halfSize, halfSize, -halfSize, -halfSize, halfSize, halfSize, -halfSize,
+				-halfSize, halfSize, -halfSize, -halfSize, -halfSize, -halfSize, -halfSize, -halfSize, -halfSize,
+				-halfSize, halfSize, -halfSize, -halfSize, halfSize, halfSize, -halfSize, -halfSize, halfSize, halfSize,
+				-halfSize, halfSize, halfSize, halfSize, halfSize, halfSize, halfSize, -halfSize, halfSize, -halfSize,
+				-halfSize, halfSize, halfSize, -halfSize, halfSize, halfSize, halfSize, -halfSize, halfSize, halfSize,
+				-halfSize, halfSize, -halfSize, -halfSize, -halfSize, -halfSize, -halfSize, -halfSize, halfSize,
+				halfSize, -halfSize, halfSize, halfSize, -halfSize, -halfSize };
 
 		radsX = (float) Math.toRadians(AngleX);
 		radsY = (float) Math.toRadians(AngleY);
@@ -51,7 +62,7 @@ public class FBPMathHelper {
 					cube[i + 1] * sinAngleX + cube[i + 2] * cosAngleX };
 			d = new double[] { d[0] * cosAngleY + d[2] * sinAngleY, d[1], d[0] * sinAngleY - d[2] * cosAngleY };
 			d = new double[] { d[0] * cosAngleZ - d[1] * sinAngleZ, d[0] * sinAngleZ + d[1] * cosAngleZ, d[2] };
-
+			
 			newVec.add(d);
 		}
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
     "modid": "fbp",
     "name": "Fancy Block Particles",
     "description": "3D Digging particles! YAY!",
-    "version": "2.0.1",
+    "version": "2.1",
     "mcversion": "1.10.2",
     "url": "https://minecraft.curseforge.com/projects/fancy-block-particles",
     "updateUrl": "",


### PR DESCRIPTION
I looked back in the chat of the mod-development channel of the MMD discord and saw that you wrote "Another reason is: I don't want to use reflection like I am right now because it's slow.". However, since Java 7, reflection can be basically the same speed as normal compiled code thanks to [MethodHandles](https://docs.oracle.com/javase/7/docs/api/java/lang/invoke/MethodHandle.html).

You don't need to use any of this code and it seems you're working on a rewrite so you may know some of this/this may not be applicable, but I want to get rid of any notion you have about reflection being slow. I'm happy to explain any parts of it in further detail.

I did some benchmarks to compare different speeds of reading a field: https://gist.github.com/Mysteryem/e3c8e6b0563e3280ee07e6b2e80546d8

Your reflection code is very slow, mainly because you're constantly re-finding whatever fields you're trying to modify, such as here https://github.com/TominoCZ/FancyBlockParticles/blob/1.10.2/src/main/java/com/TominoCZ/FBP/particle/FBPParticleEmitter.java#L62 which is roughly equivalent to getting the value of an instance field 60 times.

The changes I made should be roughly 70 times faster than before since it's effectively as if you'd used an access transformer to make the fields public and were accessing them in your source code instead of doing any reflection.

Note that it is important that the MethodHandles are static and final, otherwise the JVM can't optimise them as well.

If you had used static and final Fields instead of the MethodHandles, your code would have still been pretty fast (taking roughly twice as long normal field access)